### PR TITLE
[Merge Fix/archiver_url_directory to master] Fix broken download link

### DIFF
--- a/ckanext/archiver/command_celery.py
+++ b/ckanext/archiver/command_celery.py
@@ -52,8 +52,7 @@ class CeleryCmd(CkanCommand):
         cmd = self.args[0]
         # Don't need to load the config as the db is generally not needed
         #self._load_config()
-        # But we do want to get the filename of the ini
-        self._get_config()
+        self.filename = os.path.abspath(self.options.config)
 
         # Initialise logger after the config is loaded, so it is not disabled.
         #self.log = logging.getLogger(__name__)

--- a/ckanext/archiver/commands.py
+++ b/ckanext/archiver/commands.py
@@ -486,7 +486,7 @@ class Archiver(CkanCommand):
             {'model': model, 'ignore_auth': True, 'defer_commit': True}, {}
         )
 
-        site_url_base = config['ckanext-archiver.cache_url_root'].rstrip('/')
+        site_url_base = config['ckanext.archiver.cache_url_root'].rstrip('/')
         old_dir_regex = re.compile(r'(.*)/([a-f0-9\-]+)/([^/]*)$')
         new_dir_regex = re.compile(r'(.*)/[a-f0-9]{2}/[a-f0-9\-]{36}/[^/]*$')
         for resource in model.Session.query(model.Resource).\
@@ -513,7 +513,7 @@ class Archiver(CkanCommand):
 
             if package and package.state == model.State.DELETED:
                 print 'Package is deleted'
-                continue       
+                continue
 
             if url_base != site_url_base:
                 print 'ERROR Base URL is incorrect: %r != %r' % (url_base, site_url_base)

--- a/ckanext/archiver/default_settings.py
+++ b/ckanext/archiver/default_settings.py
@@ -1,13 +1,13 @@
 from pylons import config
 
 # directory to save downloaded files to
-ARCHIVE_DIR = config.get('ckanext-archiver.archive_dir', '/tmp/archive')
+ARCHIVE_DIR = config.get('ckanext.archiver.archive_dir', '/tmp/archive')
 
 # Max content-length of archived files, larger files will be ignored
-MAX_CONTENT_LENGTH = int(config.get('ckanext-archiver.max_content_length',
+MAX_CONTENT_LENGTH = int(config.get('ckanext.archiver.max_content_length',
                                     50000000))
 
-USER_AGENT_STRING = config.get('ckanext-archiver.user_agent_string', None)
+USER_AGENT_STRING = config.get('ckanext.archiver.user_agent_string', None)
 if not USER_AGENT_STRING:
     USER_AGENT_STRING = '%s %s ckanext-archiver' % (
         config.get('ckan.site_title', ''), config.get('ckan.site_url'))

--- a/ckanext/archiver/plugin.py
+++ b/ckanext/archiver/plugin.py
@@ -148,6 +148,9 @@ class ArchiverPlugin(p.SingletonPlugin, p.toolkit.DefaultDatasetForm):
 
     def update_config(self, config):
         p.toolkit.add_template_directory(config, 'templates')
+        archive_dir = config.get('ckanext.archiver.archive_dir')
+        if archive_dir:
+            p.toolkit.add_public_directory(config, archive_dir)
 
     # IActions
 

--- a/ckanext/archiver/tasks.py
+++ b/ckanext/archiver/tasks.py
@@ -274,7 +274,7 @@ def _update_resource(resource_id, queue, log):
     download_status_id = Status.by_text('Archived successfully')
     context = {
         'site_url': config.get('ckan.site_url_internally') or config['ckan.site_url'],
-        'cache_url_root': config.get('ckanext-archiver.cache_url_root'),
+        'cache_url_root': config.get('ckanext.archiver.cache_url_root'),
         'previous': Archival.get_for_resource(resource_id)
         }
     try:
@@ -540,8 +540,8 @@ def archive_resource(context, resource, log, result=None, url_timeout=30):
     # calculate the cache_url
     if not context.get('cache_url_root'):
         log.warning('Not saved cache_url because no value for '
-                    'ckanext-archiver.cache_url_root in config')
-        raise ArchiveError(_('No value for ckanext-archiver.cache_url_root in config'))
+                    'ckanext.archiver.cache_url_root in config')
+        raise ArchiveError(_('No value for ckanext.archiver.cache_url_root in config'))
     cache_url = urlparse.urljoin(context['cache_url_root'],
                                  '%s/%s' % (relative_archive_path, file_name))
     return {'cache_filepath': saved_file,

--- a/ckanext/archiver/tasks.py
+++ b/ckanext/archiver/tasks.py
@@ -382,11 +382,11 @@ def download(context, resource, url_timeout=30,
     if resource.get('url_type') == 'upload' and hosted_externally:
         # ckanext-cloudstorage for example does that
 
-        # enable ckanext-archiver.archive_cloud for qa to work on cloud resources
+        # enable ckanext.archiver.archive_cloud for qa to work on cloud resources
         # till https://github.com/ckan/ckanext-qa/issues/48 is resolved
         # Warning: this will result in double storage of all files below archival filesize limit
 
-        if not config.get('ckanext-archiver.archive_cloud', False):
+        if not config.get('ckanext.archiver.archive_cloud', False):
             raise ChooseNotToDownload('Skipping resource hosted externally to download resource: %s'
                                       % url,  url)
 
@@ -582,7 +582,7 @@ def get_plugins_waiting_on_ipipe():
 
 def verify_https():
     from pylons import config
-    return toolkit.asbool(config.get('ckanext-archiver.verify_https', True))
+    return toolkit.asbool(config.get('ckanext.archiver.verify_https', True))
 
 
 def _clean_content_type(ct):
@@ -934,5 +934,3 @@ def link_checker(context, data):
                 (res.status_code, res.reason)
             raise LinkHeadRequestError(error_message)
     return json.dumps(dict(headers))
-
-

--- a/ckanext/archiver/tasks.py
+++ b/ckanext/archiver/tasks.py
@@ -23,6 +23,7 @@ from ckan.lib import uploader
 from ckan import plugins as p
 from ckanext.archiver import interfaces as archiver_interfaces
 from celery.utils.log import get_task_logger
+from ckan.controllers.admin import get_sysadmins
 
 toolkit = p.toolkit
 
@@ -390,6 +391,10 @@ def download(context, resource, url_timeout=30,
                                       % url,  url)
 
     headers = _set_user_agent_string({})
+
+    if len(get_sysadmins()) > 0:
+        sysadmin = get_sysadmins()[0]
+        headers['Authorization'] = sysadmin.apikey
 
     # start the download - just get the headers
     # May raise DownloadException

--- a/ckanext/archiver/tasks.py
+++ b/ckanext/archiver/tasks.py
@@ -394,7 +394,8 @@ def download(context, resource, url_timeout=30,
 
     if len(get_sysadmins()) > 0:
         sysadmin = get_sysadmins()[0]
-        headers['Authorization'] = sysadmin.apikey
+        if url.startswith(config.get('ckan.site_url', '')):
+            headers['Authorization'] = sysadmin.apikey
 
     # start the download - just get the headers
     # May raise DownloadException

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-celery==2.4.2
-kombu==2.5
+celery==3.1.25
+kombu==3.0.37
 progressbar==2.3
 requests==2.3.0
 SQLAlchemy==0.9.6


### PR DESCRIPTION
The branch `fix/archiver_url_directory` contains fix for making the `archive_dir` files public without using any web server to serve static files on the web which fixes the download link for archived files.
Solves: https://gitlab.com/datopian/core/support/-/issues/149 

The `master` branch is currently 9 commits behind  `fix/archiver_url_directory`

Overview of  changes to be integrated to master branch if they both are merged (See commits for complete details)
- Updates the version for celery and kombu dependencies
- Replaces - with . to get archiver config settings properly
- Includes auth header if url is internal 
- Adds a public directory for archived resources