### PR TITLE
Upload archived resources to filestore

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -278,10 +278,11 @@ Config settings
       * ``ckanext.archiver.s3upload_enable`` = True to enable upload to filestore. If unset or False, the resources are going to be archived locally instead of on s3filestore.
       * ``ckanext.s3filestore.aws_storage_path`` = my-site-name. Your filestore project path. For example ckan/storage_path/archived_resource_dir. This must be set in order to upload files to filestore.
 
-    The resources are uploaded to s3filestore in directory `<S3FILESTORE__AWS_BUCKET_NAME>/<S3FILESTORE__AWS_STORAGE_PATH>/archived_resources/resource_id/archive_resource_id`.
-    A cron job must be run atleast once a week to update archived resources and generate a presigned url to download the resources from the s3filestore.The presigned url expires after 7days(604800s) of running the `archiver update` command. 
+    The resources are uploaded to s3filestore in the directory ``s3filestore.aws_bucket_name/s3filestore.aws_storage_path/archived_resources/resource_id/``.
+    
+    A cron job must be run atleast once a week to update archived resources and generate a presigned url to download the resources from the s3filestore.The presigned url expires after 7days(604800s) of running the ``archiver update`` command.::
 
-      * ``0 0 * * 0 paster --plugin=ckanext-archiver archiver update -c /srv/app/production.ini``
+      0 0 * * 0 paster --plugin=ckanext-archiver archiver update -c /srv/app/production.ini
 
 Legacy settings
 ~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -270,13 +270,13 @@ Config settings
                 root /www/resource_cache;
             }
 
-6.  If you are not serving your archived resources through a webserver, you can upload them to ``s3filestore``. 
-    Make sure you have properly setup `ckanext-s3filestore <https://github.com/datopian/ckanext-s3filestore>`_ for this.
+6.  Alternatively, you can upload archived resources to s3filestore. Make sure that you 
+    have properly setup `ckanext-s3filestore <https://github.com/datopian/ckanext-s3filestore>`_.
 
-    Add the settings to the CKAN config file:
+    Add the following values to the CKAN config file:
 
-      * ``ckanext.archiver.s3upload_enable`` = ``True`` to enable upload to filestore. If unset or ``False``, the resources are going to be archived locally instead of on s3filestore.
-      * ``ckanext.s3filestore.aws_storage_path`` = ``my-site-name``. Your filestore project path. For example ckan/storage_path/archived_resource_dir. This must be set in order to upload files to filestore.
+      * ``ckanext.archiver.s3upload_enable`` = ``True`` to enable upload to cloud storage, defaults to false.
+      * ``ckanext.s3filestore.aws_storage_path`` = ``my-site-name``. Your filestore project path. For example ckan/storage_path/archived_resource_dir. This is required to upload the archived resources.
 
     The resources are uploaded to s3filestore in the directory ``s3filestore.aws_bucket_name/s3filestore.aws_storage_path/archived_resources/resource_id/``.
     

--- a/README.rst
+++ b/README.rst
@@ -270,19 +270,20 @@ Config settings
                 root /www/resource_cache;
             }
 
-6.  If you are not serving your archived resources through a webserver, you can upload them to `s3filestore`. 
-    Make sure you have properly setup [ckanext-s3filestore](https://github.com/datopian/ckanext-s3filestore) for this.
+6.  If you are not serving your archived resources through a webserver, you can upload them to ``s3filestore``. 
+    Make sure you have properly setup `ckanext-s3filestore <https://github.com/datopian/ckanext-s3filestore>`_ for this.
 
     Add the settings to the CKAN config file:
 
-      * ``ckanext.archiver.s3upload_enable`` = True to enable upload to filestore. If unset or False, the resources are going to be archived locally instead of on s3filestore.
-      * ``ckanext.s3filestore.aws_storage_path`` = my-site-name. Your filestore project path. For example ckan/storage_path/archived_resource_dir. This must be set in order to upload files to filestore.
+      * ``ckanext.archiver.s3upload_enable`` = ``True`` to enable upload to filestore. If unset or ``False``, the resources are going to be archived locally instead of on s3filestore.
+      * ``ckanext.s3filestore.aws_storage_path`` = ``my-site-name``. Your filestore project path. For example ckan/storage_path/archived_resource_dir. This must be set in order to upload files to filestore.
 
     The resources are uploaded to s3filestore in the directory ``s3filestore.aws_bucket_name/s3filestore.aws_storage_path/archived_resources/resource_id/``.
     
-    A cron job must be run atleast once a week to update archived resources and generate a presigned url to download the resources from the s3filestore.The presigned url expires after 7days(604800s) of running the ``archiver update`` command.::
-
+    A cron job must be run atleast once a week to update archived resources and generate a presigned url to download the resources from the ``s3filestore``. The presigned url expires after 7 days(604800s) of running the ``archiver update`` command.::
+      
       0 0 * * 0 paster --plugin=ckanext-archiver archiver update -c /srv/app/production.ini
+
 
 Legacy settings
 ~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -270,6 +270,19 @@ Config settings
                 root /www/resource_cache;
             }
 
+6.  If you are not serving your archived resources through a webserver, you can upload them to `s3filestore`. 
+    Make sure you have properly setup [ckanext-s3filestore](https://github.com/datopian/ckanext-s3filestore) for this.
+
+    Add the settings to the CKAN config file:
+
+      * ``ckanext.archiver.s3upload_enable`` = True to enable upload to filestore. If unset or False, the resources are going to be archived locally instead of on s3filestore.
+      * ``ckanext.s3filestore.aws_storage_path`` = my-site-name. Your filestore project path. For example ckan/storage_path/archived_resource_dir. This must be set in order to upload files to filestore.
+
+    The resources are uploaded to s3filestore in directory `<S3FILESTORE__AWS_BUCKET_NAME>/<S3FILESTORE__AWS_STORAGE_PATH>/archived_resources/resource_id/archive_resource_id`.
+    A cron job must be run atleast once a week to update archived resources and generate a presigned url to download the resources from the s3filestore.The presigned url expires after 7days(604800s) of running the `archiver update` command. 
+
+      * ``0 0 * * 0 paster --plugin=ckanext-archiver archiver update -c /srv/app/production.ini``
+
 Legacy settings
 ~~~~~~~~~~~~~~~
 

--- a/ckanext/archiver/plugin.py
+++ b/ckanext/archiver/plugin.py
@@ -149,8 +149,6 @@ class ArchiverPlugin(p.SingletonPlugin, p.toolkit.DefaultDatasetForm):
     def update_config(self, config):
         p.toolkit.add_template_directory(config, 'templates')
         archive_dir = config.get('ckanext.archiver.archive_dir')
-        if archive_dir:
-            p.toolkit.add_public_directory(config, archive_dir)
 
     # IActions
 

--- a/ckanext/archiver/tasks.py
+++ b/ckanext/archiver/tasks.py
@@ -578,7 +578,7 @@ def upload_archived_resource(resource_id_dir, filename, saved_file):
         upload.clear = False
         upload.upload(uploader.get_max_resource_size())
 
-    return upload, filepath
+    return upload, upload.filepath
 
 def generate_cache_url(upload_obj, key_path):
     '''

--- a/ckanext/archiver/tasks.py
+++ b/ckanext/archiver/tasks.py
@@ -568,12 +568,12 @@ def upload_archived_resource(resource_id_dir, filename, saved_file):
     <S3FILESTORE__AWS_BUCKET_NAME>/<S3FILESTORE__AWS_STORAGE_PATH>/archived_resources/
     '''
     
-    if not config.get('ckanext.s3filestore.aws_storage_path'):
+    storage_path = config.get('ckanext.s3filestore.aws_storage_path')
+
+    if not storage_path:
         log.warning('Not saved to filestore because no value for '
                     'ckanext.s3filestore.aws_storage_path in config')
         raise ArchiveError(_('No value for ckanext.s3filestore.aws_storage_path in config'))
-    
-    storage_path = config.get('ckanext.s3filestore.aws_storage_path')
 
     with open (saved_file, 'rb') as save_file:
         upload = uploader.get_uploader('archived_resources')
@@ -599,7 +599,7 @@ def generate_cache_url(upload_obj, key_path):
     client = s3.client(service_name='s3', endpoint_url=host_name)
     cache_url = client.generate_presigned_url(ClientMethod='get_object',
                                               Params={'Bucket':bucket.name,'Key':key_path},
-                                              ExpiresIn=86400)
+                                              ExpiresIn=604800)
 
     return cache_url
 

--- a/ckanext/archiver/tasks.py
+++ b/ckanext/archiver/tasks.py
@@ -550,9 +550,10 @@ def archive_resource(context, resource, log, result=None, url_timeout=30):
         raise ArchiveError(_('No value for ckanext.archiver.cache_url_root in config'))
 
     archiver_s3upload_enable = config.get('ckanext.archiver.s3upload_enable')
+    resource_id_dir = relative_archive_path.split('/')[-1]
 
     if archiver_s3upload_enable:
-        upload_obj, key_path = upload_archived_resource(file_name, saved_file)
+        upload_obj, key_path = upload_archived_resource(resource_id_dir, file_name, saved_file)
         cache_url =  generate_cache_url(upload_obj, key_path)
     else:
         cache_url = urlparse.urljoin(context['cache_url_root'],
@@ -561,7 +562,7 @@ def archive_resource(context, resource, log, result=None, url_timeout=30):
     return {'cache_filepath': saved_file,
             'cache_url': cache_url}
 
-def upload_archived_resource(filename, saved_file):
+def upload_archived_resource(resource_id_dir, filename, saved_file):
     '''
     Uploads the resources to s3filestore in directory
     <S3FILESTORE__AWS_BUCKET_NAME>/<S3FILESTORE__AWS_STORAGE_PATH>/archived_resources/
@@ -572,7 +573,7 @@ def upload_archived_resource(filename, saved_file):
         upload = uploader.get_uploader('archived_resources')
         upload.upload_file = save_file
         upload.filename = filename
-        upload.filepath = os.path.join(storage_path, 'archived_resources', filename)
+        upload.filepath = os.path.join(storage_path, 'archived_resources', resource_id_dir, filename)
         upload.id = filename
         upload.clear = False
         upload.upload(uploader.get_max_resource_size())

--- a/ckanext/archiver/tasks.py
+++ b/ckanext/archiver/tasks.py
@@ -573,10 +573,11 @@ def upload_archived_resource(filename, saved_file):
         upload.upload_file = save_file
         upload.filename = filename
         upload.filepath = os.path.join(storage_path, 'archived_resources', filename)
+        upload.id = filename
         upload.clear = False
         upload.upload(uploader.get_max_resource_size())
 
-    return upload, filename
+    return upload, filepath
 
 def generate_cache_url(upload_obj, key_path):
     '''

--- a/ckanext/archiver/tasks.py
+++ b/ckanext/archiver/tasks.py
@@ -567,6 +567,12 @@ def upload_archived_resource(resource_id_dir, filename, saved_file):
     Uploads the resources to s3filestore in directory
     <S3FILESTORE__AWS_BUCKET_NAME>/<S3FILESTORE__AWS_STORAGE_PATH>/archived_resources/
     '''
+    
+    if not config.get('ckanext.s3filestore.aws_storage_path'):
+        log.warning('Not saved to filestore because no value for '
+                    'ckanext.s3filestore.aws_storage_path in config')
+        raise ArchiveError(_('No value for ckanext.s3filestore.aws_storage_path in config'))
+    
     storage_path = config.get('ckanext.s3filestore.aws_storage_path')
 
     with open (saved_file, 'rb') as save_file:


### PR DESCRIPTION
FIXES: https://gitlab.com/datopian/core/support/-/issues/149

Now all the archived resources can be uploaded to filestore.

## Description

Uploads the archived resources to s3filestore if CKANEXT__ARCHIVER__S3UPLOAD_ENABLE is set True in the .env file.

Adds two new functions

  - upload_archived_resource: Uploads the resources to s3filestore in directory <S3FILESTORE__AWS_BUCKET_NAME>/<S3FILESTORE__AWS_STORAGE_PATH>/archived_resources/resource_id/archive_resource_id
  - generate_cache_url: Generates a presigned url to download the resource from the s3filestore which expires after 1day(86400s) and returns that as cache_url
- Also removes archive_dir from public directory which was made public temporarirly for debugging.